### PR TITLE
1) Update gradle plugin.2) Provide Androidx support.3) Update artifac…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,14 +8,14 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.amazonaws.mobile.samples.appsyncsettings"
         minSdkVersion 24
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -23,7 +23,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -33,7 +33,7 @@ android {
 ext {
     anko_version = "0.10.4"
     arch_version = "1.1.1"
-    aws_sdk_version = "2.6.18"
+    aws_sdk_version = "2.13.2"
     koin_version = "0.9.1"
     support_version = "27.1.1"
 }
@@ -46,14 +46,15 @@ dependencies {
     implementation "org.jetbrains.anko:anko:$anko_version"
 
     // Android support libraries
-    implementation "com.android.support:appcompat-v7:$support_version"
-    implementation "com.android.support:design:$support_version"
-    implementation "com.android.support:support-v4:$support_version"
-    implementation "com.android.support.constraint:constraint-layout:1.1.0"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     // Android Architecture Components
-    implementation "android.arch.lifecycle:extensions:$arch_version"
-    kapt "android.arch.lifecycle:compiler:$arch_version"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation "android.arch.lifecycle:common-java8:2.2.0"
+
 
     // Dependency Injection
     implementation "org.koin:koin-android:$koin_version"

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/services/aws/AWSPreferencesRepository.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/services/aws/AWSPreferencesRepository.kt
@@ -4,8 +4,8 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.services.aws
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import android.content.Context
 import android.util.Log
 import com.amazonaws.mobile.auth.core.internal.util.ThreadUtils.runOnUiThread

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/services/interfaces/PreferencesRepository.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/services/interfaces/PreferencesRepository.kt
@@ -4,7 +4,7 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.services.interfaces
 
-import android.arch.lifecycle.LiveData
+import androidx.lifecycle.LiveData
 import com.amazonaws.mobile.samples.appsyncsettings.models.Theme
 
 /**

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/services/mock/MockPreferencesRepository.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/services/mock/MockPreferencesRepository.kt
@@ -4,8 +4,8 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.services.mock
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.amazonaws.mobile.samples.appsyncsettings.models.Theme
 import com.amazonaws.mobile.samples.appsyncsettings.models.Themes
 import com.amazonaws.mobile.samples.appsyncsettings.services.interfaces.PreferencesRepository

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/ui/AuthenticatorActivity.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/ui/AuthenticatorActivity.kt
@@ -4,7 +4,7 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.ui
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.amazonaws.mobile.auth.ui.SignInUI
 import com.amazonaws.mobile.client.AWSMobileClient

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/ui/MainActivity.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/ui/MainActivity.kt
@@ -4,12 +4,12 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.ui
 
-import android.arch.lifecycle.Observer
+import androidx.lifecycle.Observer
 import android.content.Intent
 import android.graphics.drawable.ColorDrawable
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.support.v4.view.GravityCompat
+import androidx.core.view.GravityCompat
 import android.view.MenuItem
 import com.amazonaws.mobile.samples.appsyncsettings.R
 import com.amazonaws.mobile.samples.appsyncsettings.models.Theme

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/ui/PreferencesActivity.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/ui/PreferencesActivity.kt
@@ -4,9 +4,9 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.ui
 
-import android.arch.lifecycle.Observer
+import androidx.lifecycle.Observer
 import android.graphics.drawable.ColorDrawable
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/viewmodels/MainActivityViewModel.kt
@@ -4,8 +4,8 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.viewmodels
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.ViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
 import com.amazonaws.mobile.samples.appsyncsettings.models.Theme
 import com.amazonaws.mobile.samples.appsyncsettings.services.interfaces.PreferencesRepository
 

--- a/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/viewmodels/PreferencesActivityViewModel.kt
+++ b/app/src/main/java/com/amazonaws/mobile/samples/appsyncsettings/viewmodels/PreferencesActivityViewModel.kt
@@ -4,8 +4,8 @@
  */
 package com.amazonaws.mobile.samples.appsyncsettings.viewmodels
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.ViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
 import com.amazonaws.mobile.samples.appsyncsettings.models.Theme
 import com.amazonaws.mobile.samples.appsyncsettings.services.interfaces.PreferencesRepository
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,7 +3,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0.
 -->
-<android.support.v4.widget.DrawerLayout
+<androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -12,11 +12,11 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.MainActivity">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/main_toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
@@ -24,9 +24,9 @@
             android:elevation="4dp"
             android:theme="@style/ToolbarTheme"
             android:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <android.support.design.widget.NavigationView
+    <com.google.android.material.navigation.NavigationView
         android:id="@+id/main_navigationview"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -35,4 +35,4 @@
         app:headerLayout="@layout/nav_header"
         app:menu="@menu/nav_menu"/>
     
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -3,14 +3,14 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0.
 -->
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.PreferencesActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/prefs_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
@@ -47,4 +47,4 @@
         app:layout_constraintTop_toBottomOf="@+id/prefs_theme_spinner" />
 
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -3,10 +3,10 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0.
 -->
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="200dp"
     android:background="@color/colorPrimaryDark">
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@
 
 
 buildscript {
-    ext.kotlin_version = '1.2.40'
-    ext.appsync_version = '2.6.17'
+    ext.kotlin_version = '1.3.70'
+    ext.appsync_version = '2.8.3'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha12'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.amazonaws:aws-android-sdk-appsync-gradle-plugin:$appsync_version"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 24 11:02:58 PDT 2018
+#Wed Mar 11 12:45:23 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
1) Error:- The project is using an incompatible version of the Android Gradle plugin.  To continue opening the project, the IDE will update the plugin to version 3.6.1.

Solution:- Update Android gradle plugin version to 3.6.1

2) ERROR:- The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.10 and higher.
The following dependencies do not satisfy the required version:
root project 'aws-mobile-appsync-android-settings' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.40

Solution:- Update kotlin version to 1.3.70

3) Error:- The specified Android SDK Build Tools version (27.0.3) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.6.1.

Solution:- Update buildToolsVersion to 28.0.3 and compileSdkVersion to 28 targetSdkVersion to 28.

4) Error:- Some problems were found with the configuration of task ':app:generateDebugApolloIR'.
> Value 'debug GraphQL source' specified for property '$2' cannot be converted to a file.
> Value 'main GraphQL source' specified for property '$1' cannot be converted to a file.

Solution:- a) Upgrade aws_sdk_version -> 2.13.2 b) Upgrade appsync_version -> 2.8.3

Apart from that integrate Androidx support and use latest artifacts where required.

Remove kapt "android.arch.lifecycle:compiler:$arch_version" and add implementation "android.arch.lifecycle:common-java8:2.2.0" as suggested by [official documentation](https://developer.android.com/jetpack/androidx/releases/lifecycle#version_230_2).

// Annotation processor
kapt "androidx.lifecycle:lifecycle-compiler:$lifecycle_version"
// alternately - if using Java8, use the following instead of lifecycle-compiler
implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
